### PR TITLE
Fix the 250 log line at each tick when AGExt is installed.

### DIFF
--- a/KerbalSimpit/Providers/ActionGroups.cs
+++ b/KerbalSimpit/Providers/ActionGroups.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using KSP.IO;
@@ -209,6 +210,29 @@ namespace KerbalSimpit.Providers
 
             if (AGXPresent)
             {
+                Type AGXFlight = Type.GetType("ActionGroupsExtended.AGXFlight, AGExt");
+
+                Dictionary<int, bool> groupActivatedState = (Dictionary<int, bool>) AGXFlight.InvokeMember("groupActivatedState",
+                    BindingFlags.GetField | BindingFlags.Public | BindingFlags.Static, null, null, null);
+
+                foreach (KeyValuePair<int, bool> item in groupActivatedState)
+                {
+                    int group = item.Key;
+                    if(group > 250)
+                    {
+                        Debug.Log("Simpit : ignoring an action that is above the 250 actions allowed with AGExt");
+                    } else
+                    {
+                        if (item.Value)
+                        {
+                            result.status[group / 8] |= (byte)(1 << group % 8); //Set the selected bit to 1
+                        }
+                    }
+                }
+
+                /*
+                // The following code use the 'official' AGExt External API, but each call actually log one line
+                // So each tick, this generate 250 log line. To avoid this, another method is used (see above)
                 for (int group = 1; group <= 250; group++) //Ignoring 0 since there is no Action Group 0
                 {
                     bool activated = (bool) AGXExternal.InvokeMember("AGXGroupState",
@@ -218,7 +242,7 @@ namespace KerbalSimpit.Providers
                     {
                         result.status[group / 8] |= (byte) (1 << group % 8); //Set the selected bit to 1
                     }
-                }
+                }*/
             } else
             {
                 for(int i = 1; i < ActionGroupIDs.Length; i++) //Ignoring 0 since there is no Action Group 0


### PR DESCRIPTION
This PR use another method to get the action states when AGExt is installed to avoid using the 'official' External AGExt API that log a line at each call.

My test show that the basic functionality works, but sometimes an action triggered is not updated on AGExt side. The content of the groupActivatedState dictionnary (provided by AGExt) does not seem up to date. This was already the case with the previous code. 