### PR TITLE
fix: Fixed reconnecting controllers not binding

### DIFF
--- a/KerbalSimpit/Console/KerbalSimpitConsole_SerialCommand.cs
+++ b/KerbalSimpit/Console/KerbalSimpitConsole_SerialCommand.cs
@@ -60,7 +60,7 @@ namespace KerbalSimpit.Console
                 {
                     if (KSPit.serialPorts.First().Value.portConnected == false)
                     {
-                        this.k_simpit.initPorts();
+                        this.k_simpit.OpenPorts();
                     }
                 }
                 // Else if they have not been connected to before, run this

--- a/KerbalSimpit/KerbalSimpit.cs
+++ b/KerbalSimpit/KerbalSimpit.cs
@@ -101,6 +101,10 @@ namespace KerbalSimpit
                 this.toSerialArray[i] = new EventData<byte, object>(String.Format("toSerial{0}", i));
             }
 
+            this.onSerialReceivedArray[CommonPackets.Synchronisation].Add(this.handshakeCallback);
+            this.onSerialReceivedArray[InboundPackets.RegisterHandler].Add(this.registerCallback);
+            this.onSerialReceivedArray[InboundPackets.DeregisterHandler].Add(this.deregisterCallback);
+
             Config = new KerbalSimpitConfig();
 
             SerialPorts = createPortList(Config);
@@ -109,15 +113,13 @@ namespace KerbalSimpit
             // Open the ports, for this classes instance
             this.OpenPorts();
 
-            this.onSerialReceivedArray[CommonPackets.Synchronisation].Add(this.handshakeCallback);
-            this.onSerialReceivedArray[InboundPackets.RegisterHandler].Add(this.registerCallback);
-            this.onSerialReceivedArray[InboundPackets.DeregisterHandler].Add(this.deregisterCallback);
+            Debug.Log("KerbalSimpit: Started");
+        }
 
+        private void StartEventDispatch(){
             this.EventDispatchThread = new Thread(this.EventWorker);
             this.EventDispatchThread.Start();
-            while (!this.EventDispatchThread.IsAlive) ;
-
-            Debug.Log("KerbalSimpit: Started");
+            while (!this.EventDispatchThread.IsAlive);
         }
 
         public void OnDestroy()
@@ -252,6 +254,9 @@ namespace KerbalSimpit
             
             // Run connect set to true, signalling that the list has been populated at least once
             runConnect = true;
+
+            StartEventDispatch();
+
         }
 
         public void ClosePorts() {


### PR DESCRIPTION
These changes should have fixed an issue that we were facing in regards
to reconnecting a controller while in the flight scene. It appears that
the event dispatch thread was not being restarted when the serial start
command was being issued by a user in the terminal.

Also changed the serial start command to actually call the intended
method when the command is issued.