### PR TITLE
Fix an issue where the current SOI is not sent when the channel is first requested

### DIFF
--- a/KerbalSimpit/KerbalSimpit.cs
+++ b/KerbalSimpit/KerbalSimpit.cs
@@ -316,6 +316,14 @@ namespace KerbalSimpit
                     Debug.Log(String.Format("KerbalSimpit: Serial port {0} subscribing to channel {1}", portID, idx));
                 }
                 toSerialArray[idx].Add(SerialPorts[portID].sendPacket);
+
+                // Since the SOI name is only updated when it changes, it is not sent after the channel registration.
+                // For now, when the channel subscribed is the current SOI, force the sending of a SOI packet.
+                if(idx == OutboundPackets.SoIName)
+                {
+                    Providers.KerbalSimpitTelemetryProvider telemetry = (Providers.KerbalSimpitTelemetryProvider) FindObjectOfType(typeof(Providers.KerbalSimpitTelemetryProvider));
+                    telemetry.resendSOI();
+                }
             }
         }
 

--- a/KerbalSimpit/Providers/Actions.cs
+++ b/KerbalSimpit/Providers/Actions.cs
@@ -23,6 +23,10 @@ namespace KerbalSimpit.Providers
         private volatile byte activateBuffer, deactivateBuffer,
             toggleBuffer, currentStateBuffer;
 
+        // If set to true, the state should be sent at the next update even if no changes
+        // are detected (for instance to initialise it after a new registration).
+        private bool resendState = false;
+
         public void Start()
         {
             activateBuffer = 0;
@@ -38,6 +42,7 @@ namespace KerbalSimpit.Providers
             if (AGToggleChannel != null) AGToggleChannel.Add(actionToggleCallback);
 
             AGStateChannel = GameEvents.FindEvent<EventData<byte, object>>("toSerial40");
+            GameEvents.FindEvent<EventData<byte, object>>("onSerialChannelSubscribed" + OutboundPackets.ActionGroups).Add(resendActionGroup);
         }
 
         public void OnDestroy()
@@ -45,6 +50,11 @@ namespace KerbalSimpit.Providers
             if (AGActivateChannel != null) AGActivateChannel.Remove(actionActivateCallback);
             if (AGDeactivateChannel != null) AGDeactivateChannel.Remove(actionDeactivateCallback);
             if (AGToggleChannel != null) AGToggleChannel.Remove(actionToggleCallback);
+        }
+
+        public void resendActionGroup(byte ID, object Data)
+        {
+            resendState = true;
         }
 
         public void Update()
@@ -90,8 +100,9 @@ namespace KerbalSimpit.Providers
         private bool updateCurrentState()
         {
             byte newState = getGroups();
-            if (newState != currentStateBuffer)
+            if (newState != currentStateBuffer || resendState)
             {
+                resendState = false;
                 if (AGStateChannel != null) AGStateChannel.Fire(OutboundPackets.ActionGroups, newState);
                 return true;
             } else {

--- a/KerbalSimpit/Providers/Telemetry.cs
+++ b/KerbalSimpit/Providers/Telemetry.cs
@@ -142,6 +142,11 @@ namespace KerbalSimpit.Providers
             }
         }
 
+        public void resendSOI()
+        {
+            CurrentSoI = "";
+        }
+
         public void AltitudeProvider()
         {
             myAlt.alt = (float)FlightGlobals.ActiveVessel.altitude;

--- a/KerbalSimpit/Providers/Telemetry.cs
+++ b/KerbalSimpit/Providers/Telemetry.cs
@@ -112,7 +112,9 @@ namespace KerbalSimpit.Providers
             // We fire one SoI packet when SoI changes. So no need to use the
             // periodic DeviceHandler infrastructure.
             CurrentSoI = "";
-            soiChannel = GameEvents.FindEvent<EventData<byte, object>>("toSerial51");
+            soiChannel = GameEvents.FindEvent<EventData<byte, object>>("toSerial" + OutboundPackets.SoIName);
+            //When SOIName channel is subscribed to, we need to resend the SOI name.
+            GameEvents.FindEvent<EventData<byte, object>>("onSerialChannelSubscribed" + OutboundPackets.SoIName).Add(resendSOI);
             KSPit.AddToDeviceHandler(AirspeedProvider);
             airspeedChannel = GameEvents.FindEvent<EventData<byte, object>>("toSerial32");
         }
@@ -142,7 +144,7 @@ namespace KerbalSimpit.Providers
             }
         }
 
-        public void resendSOI()
+        public void resendSOI(byte ID, object Data)
         {
             CurrentSoI = "";
         }


### PR DESCRIPTION
Fix for #42 

This is a dirty fix, a more generic approach could be used in the future to deal with other messages that are only sent on changes (Action groups for instance)